### PR TITLE
Button: prevent double-click & add loader

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,7 @@ module.exports = {
     "linebreak-style": ["error", "unix"],
     camelcase: ["error"],
 
-    // Don't allow console.log
-    "no-console": ["error"],
+    // Allow console.log
     "@typescript-eslint/no-unused-vars": [
       "error",
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },

--- a/components/Button/index.scss
+++ b/components/Button/index.scss
@@ -1,10 +1,6 @@
 .Button {
   @apply relative border border-transparent font-medium leading-4 shadow-sm;
 
-  &--isLoading {
-    @apply cursor-progress;
-  }
-
   // Round if no rounding class is specified
   &:not([class*="rounded"]) {
     @apply rounded-md;

--- a/components/Button/index.scss
+++ b/components/Button/index.scss
@@ -1,5 +1,9 @@
 .Button {
-  @apply border border-transparent font-medium leading-4 shadow-sm;
+  @apply relative border border-transparent font-medium leading-4 shadow-sm;
+
+  &--isLoading {
+    @apply cursor-progress;
+  }
 
   // Round if no rounding class is specified
   &:not([class*="rounded"]) {

--- a/components/Button/index.test.tsx
+++ b/components/Button/index.test.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, waitFor } from "@testing-library/react"
 
 import Button, { ButtonProps } from "."
+import userEvent from "@testing-library/user-event"
 
 const defaultProps: ButtonProps = {
   children: "Button text",
@@ -22,7 +23,7 @@ describe(Button, () => {
 
       const button = getByText(defaultProps.children as string)
 
-      expect(button).toHaveClass("Button--md")
+      expect(button.parentElement).toHaveClass("Button--md")
     })
   })
 
@@ -34,7 +35,31 @@ describe(Button, () => {
 
       const button = getByText(defaultProps.children as string)
 
-      expect(button).toHaveClass("Button--primary")
+      expect(button.parentElement).toHaveClass("Button--primary")
+    })
+  })
+
+  describe("when user clicks", () => {
+    it("shows a loader", async () => {
+      const { getByText } = render(
+        <Button
+          {...defaultProps}
+          onClick={() => new Promise((resolve) => setTimeout(resolve, 200))}
+        />
+      )
+      await userEvent.click(getByText(defaultProps.children as string))
+      await waitFor(() => expect(getByText("Loading...")).toBeInTheDocument())
+    })
+
+    it("prevents calling onClick twice", async () => {
+      const onClickFunc = jest.fn(
+        () => new Promise((resolve) => setTimeout(resolve, 200))
+      )
+      const { getByText } = render(
+        <Button {...defaultProps} onClick={onClickFunc} />
+      )
+      await userEvent.dblClick(getByText(defaultProps.children as string))
+      expect(onClickFunc).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -35,7 +35,7 @@ export default function Button(props: ButtonProps): JSX.Element {
     {
       [`Button--${size}`]: size,
       [`Button--${variant}`]: variant,
-      [`Button--isLoading`]: isLoading,
+      [`cursor-progress`]: isLoading,
     },
     className
   )

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { MouseEventHandler, useState } from "react"
 import classNames from "classnames"
 import "./index.scss"
 
@@ -17,16 +17,43 @@ export interface ButtonProps
 }
 
 export default function Button(props: ButtonProps): JSX.Element {
-  const { size, variant, className, ...rest } = props
+  const { size, variant, className, onClick, children, ...rest } = props
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = async (e) => {
+    if (isLoading) return
+    setIsLoading(true)
+    try {
+      await Promise.resolve(onClick?.(e))
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   const usedClassName = classNames(
     "Button",
     {
       [`Button--${size}`]: size,
       [`Button--${variant}`]: variant,
+      [`Button--isLoading`]: isLoading,
     },
     className
   )
 
-  return <button className={usedClassName} {...rest} />
+  return (
+    <button
+      className={usedClassName}
+      {...(onClick ? { onClick: handleClick } : {})}
+      {...rest}
+    >
+      <div className={isLoading ? "invisible" : "visible"}>{children}</div>
+      <div
+        className={`absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 ${
+          isLoading ? "visible" : "invisible"
+        }`}
+      >
+        <p>Loading...</p>
+      </div>
+    </button>
+  )
 }

--- a/components/ButtonClear/index.scss
+++ b/components/ButtonClear/index.scss
@@ -1,5 +1,5 @@
 .ButtonClear {
-  @apply border border-transparent bg-transparent rounded-md leading-4 active:shadow-sm;
+  @apply relative border border-transparent bg-transparent rounded-md leading-4 active:shadow-sm;
 
   // Sizes
   &--xs {

--- a/components/ButtonClear/index.test.tsx
+++ b/components/ButtonClear/index.test.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, waitFor } from "@testing-library/react"
 
 import ButtonClear, { ButtonClearProps } from "."
+import userEvent from "@testing-library/user-event"
 
 const defaultProps: ButtonClearProps = {
   children: "ButtonClear text",
@@ -22,7 +23,7 @@ describe(ButtonClear, () => {
 
       const button = getByText(defaultProps.children as string)
 
-      expect(button).toHaveClass("ButtonClear--md")
+      expect(button.parentElement).toHaveClass("ButtonClear--md")
     })
   })
 
@@ -34,7 +35,31 @@ describe(ButtonClear, () => {
 
       const button = getByText(defaultProps.children as string)
 
-      expect(button).toHaveClass("ButtonClear--primary")
+      expect(button.parentElement).toHaveClass("ButtonClear--primary")
+    })
+  })
+
+  describe("when user clicks", () => {
+    it("shows a loader", async () => {
+      const { getByText } = render(
+        <ButtonClear
+          {...defaultProps}
+          onClick={() => new Promise((resolve) => setTimeout(resolve, 200))}
+        />
+      )
+      await userEvent.click(getByText(defaultProps.children as string))
+      await waitFor(() => expect(getByText("Loading...")).toBeInTheDocument())
+    })
+
+    it("prevents calling onClick twice", async () => {
+      const onClickFunc = jest.fn(
+        () => new Promise((resolve) => setTimeout(resolve, 200))
+      )
+      const { getByText } = render(
+        <ButtonClear {...defaultProps} onClick={onClickFunc} />
+      )
+      await userEvent.dblClick(getByText(defaultProps.children as string))
+      expect(onClickFunc).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/components/ButtonClear/index.tsx
+++ b/components/ButtonClear/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { MouseEventHandler, useState } from "react"
 import classNames from "classnames"
 import "./index.scss"
 
@@ -17,16 +17,43 @@ export interface ButtonClearProps
 }
 
 export default function ButtonClear(props: ButtonClearProps): JSX.Element {
-  const { size, variant, className, ...rest } = props
+  const { size, variant, className, onClick, children, ...rest } = props
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = async (e) => {
+    if (isLoading) return
+    setIsLoading(true)
+    try {
+      await Promise.resolve(onClick?.(e))
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   const usedClassName = classNames(
     "ButtonClear",
     {
       [`ButtonClear--${size}`]: size,
       [`ButtonClear--${variant}`]: variant,
+      [`cursor-progress`]: isLoading,
     },
     className
   )
 
-  return <button className={usedClassName} {...rest} />
+  return (
+    <button
+      className={usedClassName}
+      {...(onClick ? { onClick: handleClick } : {})}
+      {...rest}
+    >
+      <div className={isLoading ? "invisible" : "visible"}>{children}</div>
+      <div
+        className={`absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 ${
+          isLoading ? "visible" : "invisible"
+        }`}
+      >
+        <p>Loading...</p>
+      </div>
+    </button>
+  )
 }

--- a/components/ButtonOutline/index.scss
+++ b/components/ButtonOutline/index.scss
@@ -1,5 +1,5 @@
 .ButtonOutline {
-  @apply border border-solid bg-transparent font-medium leading-4 shadow-sm;
+  @apply relative border border-solid bg-transparent font-medium leading-4 shadow-sm;
 
   // Round if no rounding class is specified
   &:not([class*="rounded"]) {

--- a/components/ButtonOutline/index.test.tsx
+++ b/components/ButtonOutline/index.test.tsx
@@ -1,7 +1,8 @@
 import React from "react"
-import { render } from "@testing-library/react"
+import { render, waitFor } from "@testing-library/react"
 
 import ButtonOutline, { ButtonOutlineProps } from "."
+import userEvent from "@testing-library/user-event"
 
 const defaultProps: ButtonOutlineProps = {
   children: "ButtonOutline text",
@@ -24,7 +25,7 @@ describe(ButtonOutline, () => {
 
       const button = getByText(defaultProps.children as string)
 
-      expect(button).toHaveClass("ButtonOutline--md")
+      expect(button.parentElement).toHaveClass("ButtonOutline--md")
     })
   })
 
@@ -36,7 +37,31 @@ describe(ButtonOutline, () => {
 
       const button = getByText(defaultProps.children as string)
 
-      expect(button).toHaveClass("ButtonOutline--primary")
+      expect(button.parentElement).toHaveClass("ButtonOutline--primary")
+    })
+  })
+
+  describe("when user clicks", () => {
+    it("shows a loader", async () => {
+      const { getByText } = render(
+        <ButtonOutline
+          {...defaultProps}
+          onClick={() => new Promise((resolve) => setTimeout(resolve, 200))}
+        />
+      )
+      await userEvent.click(getByText(defaultProps.children as string))
+      await waitFor(() => expect(getByText("Loading...")).toBeInTheDocument())
+    })
+
+    it("prevents calling onClick twice", async () => {
+      const onClickFunc = jest.fn(
+        () => new Promise((resolve) => setTimeout(resolve, 200))
+      )
+      const { getByText } = render(
+        <ButtonOutline {...defaultProps} onClick={onClickFunc} />
+      )
+      await userEvent.dblClick(getByText(defaultProps.children as string))
+      expect(onClickFunc).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/components/ButtonOutline/index.tsx
+++ b/components/ButtonOutline/index.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { MouseEventHandler, useState } from "react"
 import classNames from "classnames"
 import "./index.scss"
 
@@ -17,16 +17,43 @@ export interface ButtonOutlineProps
 }
 
 export default function ButtonOutline(props: ButtonOutlineProps): JSX.Element {
-  const { size, variant, className, ...rest } = props
+  const { size, variant, className, onClick, children, ...rest } = props
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = async (e) => {
+    if (isLoading) return
+    setIsLoading(true)
+    try {
+      await Promise.resolve(onClick?.(e))
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   const usedClassName = classNames(
     "ButtonOutline",
     {
       [`ButtonOutline--${size}`]: size,
       [`ButtonOutline--${variant}`]: variant,
+      [`cursor-progress`]: isLoading,
     },
     className
   )
 
-  return <button className={usedClassName} {...rest} />
+  return (
+    <button
+      className={usedClassName}
+      {...(onClick ? { onClick: handleClick } : {})}
+      {...rest}
+    >
+      <div className={isLoading ? "invisible" : "visible"}>{children}</div>
+      <div
+        className={`absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 ${
+          isLoading ? "visible" : "invisible"
+        }`}
+      >
+        <p>Loading...</p>
+      </div>
+    </button>
+  )
 }

--- a/stories/components/Button.stories.tsx
+++ b/stories/components/Button.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ComponentStory, ComponentMeta } from "@storybook/react"
+import { Meta, StoryFn } from "@storybook/react"
 
 import Button, { ButtonProps } from "~/components/Button"
 
@@ -7,15 +7,19 @@ import Button, { ButtonProps } from "~/components/Button"
 export default {
   title: "Design System/Button",
   component: Button,
-} as ComponentMeta<typeof Button>
+} as Meta<typeof Button>
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
+const Template: StoryFn<typeof Button> = (args) => <Button {...args} />
 
 const sharedProps: Partial<ButtonProps> = {
   children: "Button text",
   size: "md",
   disabled: false,
+  onClick: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    console.log("onClick work finished")
+  },
 }
 
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/stories/components/ButtonClear.stories.tsx
+++ b/stories/components/ButtonClear.stories.tsx
@@ -1,16 +1,15 @@
 import React from "react"
-import { ComponentStory, ComponentMeta } from "@storybook/react"
-
+import { Meta, StoryFn } from "@storybook/react"
 import ButtonClear, { ButtonClearProps } from "~/components/ButtonClear"
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
   title: "Design System/ButtonClear",
   component: ButtonClear,
-} as ComponentMeta<typeof ButtonClear>
+} as Meta<typeof ButtonClear>
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof ButtonClear> = (args) => (
+const Template: StoryFn<typeof ButtonClear> = (args) => (
   <ButtonClear {...args} />
 )
 
@@ -18,6 +17,10 @@ const sharedProps: Partial<ButtonClearProps> = {
   children: "Button text",
   size: "md",
   disabled: false,
+  onClick: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    console.log("onClick work finished")
+  },
 }
 
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/stories/components/ButtonOutline.stories.tsx
+++ b/stories/components/ButtonOutline.stories.tsx
@@ -1,16 +1,15 @@
 import React from "react"
-import { ComponentStory, ComponentMeta } from "@storybook/react"
-
+import { StoryFn, Meta } from "@storybook/react"
 import ButtonOutline, { ButtonOutlineProps } from "~/components/ButtonOutline"
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
-  title: "Toolbox/ButtonOutline",
+  title: "Design System/ButtonOutline",
   component: ButtonOutline,
-} as ComponentMeta<typeof ButtonOutline>
+} as Meta<typeof ButtonOutline>
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof ButtonOutline> = (args) => (
+const Template: StoryFn<typeof ButtonOutline> = (args) => (
   <ButtonOutline {...args} />
 )
 
@@ -18,6 +17,10 @@ const sharedProps: Partial<ButtonOutlineProps> = {
   children: "Button text",
   size: "md",
   disabled: false,
+  onClick: async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    console.log("onClick work finished")
+  },
 }
 
 // More on args: https://storybook.js.org/docs/react/writing-stories/args


### PR DESCRIPTION
Pet peeves of mine: 
- developers forgetting that `<button />` onClick can be called twice by default
- `<button />` changing width/height when showing a loading text/component

This PR is intended to solve above points by:
- handling onClick with `isLoading` state in the Button component
- defaulting to a 'Loading...' text that is easy to change & displaying the necessary TW classes to center inside the button

Changed .eslintrc to allow console.log statements